### PR TITLE
Eliminate warning: unused Result that must be used

### DIFF
--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -77,7 +77,7 @@ pub fn read_file_to_string(path: String) -> String {
 pub fn error_and_quit(msg: &str) -> ! {
     error!("{}, 按Enter退出", msg);
     let mut s: String = String::new();
-    stdin().read_line(&mut s);
+    let _ = stdin().read_line(&mut s);
     process::exit(0);
 }
 

--- a/src/expo/mona_uranai.rs
+++ b/src/expo/mona_uranai.rs
@@ -96,8 +96,8 @@ impl ArtifactSlot {
 impl Serialize for ArtifactStat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         let mut root = serializer.serialize_map(Some(2))?;
-        root.serialize_entry("name", &self.name.to_mona());
-        root.serialize_entry("value", &self.value);
+        root.serialize_entry("name", &self.name.to_mona())?;
+        root.serialize_entry("value", &self.value)?;
         root.end()
     }
 }
@@ -106,9 +106,9 @@ impl Serialize for MonaArtifact {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         let mut root = serializer.serialize_map(Some(7))?;
 
-        root.serialize_entry("setName", &self.set_name.to_mona());
-        root.serialize_entry("position", &self.slot.to_mona());
-        root.serialize_entry("mainTag", &self.main_stat);
+        root.serialize_entry("setName", &self.set_name.to_mona())?;
+        root.serialize_entry("position", &self.slot.to_mona())?;
+        root.serialize_entry("mainTag", &self.main_stat)?;
 
         let mut sub_stats: Vec<&ArtifactStat> = vec![];
         if let Some(ref s) = self.sub_stat_1 {
@@ -131,10 +131,10 @@ impl Serialize for MonaArtifact {
         // subs.end();
         // subs.
 
-        root.serialize_entry("normalTags", &sub_stats);
-        root.serialize_entry("omit", &false);
-        root.serialize_entry("level", &self.level);
-        root.serialize_entry("star", &self.star);
+        root.serialize_entry("normalTags", &sub_stats)?;
+        root.serialize_entry("omit", &false)?;
+        root.serialize_entry("level", &self.level)?;
+        root.serialize_entry("star", &self.star)?;
 
         root.end()
     }
@@ -152,12 +152,12 @@ pub struct MonaFormat<'a> {
 impl<'a> Serialize for MonaFormat<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         let mut root = serializer.serialize_map(Some(6))?;
-        root.serialize_entry("version", &self.version);
-        root.serialize_entry("flower", &self.flower);
-        root.serialize_entry("feather", &self.feather);
-        root.serialize_entry("sand", &self.sand);
-        root.serialize_entry("cup", &self.cup);
-        root.serialize_entry("head", &self.head);
+        root.serialize_entry("version", &self.version)?;
+        root.serialize_entry("flower", &self.flower)?;
+        root.serialize_entry("feather", &self.feather)?;
+        root.serialize_entry("sand", &self.sand)?;
+        root.serialize_entry("cup", &self.cup)?;
+        root.serialize_entry("head", &self.head)?;
         root.end()
     }
 }

--- a/src/scanner/yas_scanner.rs
+++ b/src/scanner/yas_scanner.rs
@@ -363,11 +363,11 @@ impl YasScanner {
     }
 
     fn start_capture_only(&mut self) {
-        fs::create_dir("captures");
+        fs::create_dir("captures").expect("couldn't create directory: captures");
         let info = &self.info.clone();
 
         let count = self.info.art_count_position.capture_relative(info).unwrap();
-        count.to_gray_image().save("captures/count.png");
+        count.to_gray_image().save("captures/count.png").expect("couldn't create file: captures/count.png");
 
         let convert_rect = |rect: &PixelRectBound| {
             PixelRect {


### PR DESCRIPTION
使用?算符消除编译器警告 unused `Result` that must be used，并减少使用unwrap，让主函数尽量向上抛出错误减少panic。