### PR TITLE
Add build.target to config.toml to automatically cross-compile.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-pc-windows-gnu"


### PR DESCRIPTION
When developing on macOS, cargo build could not automatically find the correct target. Add this config.toml could fix this problem and help IDE like Clion to correctly build cache and eliminate errors like "could not resolve winapi".  