### PR TITLE
Add support for 43:18 ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ yas --min-star=5
 yas --max-row=1
 ```
 
+## 编译
+
+```shell
+# Linux下需要首先安装rustup以及mingw-w64，然后再安装对应的rust target，
+rustup default stable
+rustup target add x86_64-pc-windows-gnu
+cargo build --release --locked --target=x86_64-pc-windows-gnu
+```
+
 ## 反馈
 - Issue
 - QQ群：801106595

--- a/src/info/info.rs
+++ b/src/info/info.rs
@@ -1,5 +1,5 @@
 use crate::common::{PixelRect, PixelRectBound};
-use crate::info::window_info::{WINDOW_16_9, WINDOW_4_3, WINDOW_8_5};
+use crate::info::window_info::{WINDOW_43_18, WINDOW_16_9, WINDOW_4_3, WINDOW_8_5};
 
 #[derive(Clone, Debug)]
 pub struct ScanInfo {
@@ -47,6 +47,10 @@ pub struct ScanInfo {
 }
 
 impl ScanInfo {
+    pub fn from_43_18(width: u32, height: u32, left: i32, top: i32) -> ScanInfo {
+        WINDOW_43_18.to_scan_info(height as f64, width as f64, left, top)
+    }
+
     pub fn from_16_9(width: u32, height: u32, left: i32, top: i32) -> ScanInfo {
         WINDOW_16_9.to_scan_info(height as f64, width as f64, left, top)
     }

--- a/src/info/window_info.rs
+++ b/src/info/window_info.rs
@@ -100,6 +100,44 @@ impl WindowInfo {
     }
 }
 
+pub const WINDOW_43_18: WindowInfo = WindowInfo {
+    width: 3440.0,
+    height: 1440.0,
+
+    title_pos: Rect(170.0, 3140.0, 220.0, 2560.0),
+    main_stat_name_pos: Rect(360.0, 2850.0, 400.0, 2560.0),
+    main_stat_value_pos: Rect(400.0, 2850.0, 460.0, 2560.0),
+    level_pos: Rect(575.0, 2640.0, 605.0, 2568.0),
+    panel_pos: Rect(160.0, 3185.0, 1280.0, 2528.0),
+
+    sub_stat1_pos: Rect(640.0, 3080.0, 680.0, 2590.0),
+    sub_stat2_pos: Rect(690.0, 3080.0, 730.0, 2590.0),
+    sub_stat3_pos: Rect(742.0, 3080.0, 782.0, 2590.0),
+    sub_stat4_pos: Rect(795.0, 3080.0, 835.0, 2590.0),
+
+    equip_pos: Rect(1220.0, 5630.0, 1260.0, 3140.0),
+    art_count_pos: Rect(50.0, 3185.0, 85.0, 2750.0),
+
+    art_width: 2421.0 - 2257.0,
+    art_height: 598.0 - 394.0,
+    art_gap_x: 2257.0 - 2225.0,
+    art_gap_y: 394.0 - 363.0,
+
+    art_row: 5,
+    art_col: 11,
+
+    left_margin: 305.0,
+    top_margin: 161.0,
+
+    flag_x: 580.0,
+    flag_y: 145.0,
+
+    star_x: 3130.0,
+    star_y: 200.0,
+    
+    pool_pos: Rect(170.0, 2610.0 + 30.0, 900.0, 2610.0)
+};
+
 pub const WINDOW_16_9: WindowInfo = WindowInfo {
     width: 1600.0,
     height: 900.0,
@@ -134,7 +172,7 @@ pub const WINDOW_16_9: WindowInfo = WindowInfo {
 
     star_x: 1469.4,
     star_y: 123.9,
-
+    
     pool_pos: Rect(118.2, 1144.7 + 15.0, 510.3, 1144.7)
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,9 @@ fn main() {
     let temp = capture_absolute_image(&rect).unwrap().save("test.png");
 
     let mut info: info::ScanInfo;
-    if rect.height * 16 == rect.width * 9 {
+    if rect.height * 43 == rect.width * 18 {
+        info = info::ScanInfo::from_43_18(rect.width as u32, rect.height as u32, rect.left, rect.top);
+    } else if rect.height * 16 == rect.width * 9 {
         info = info::ScanInfo::from_16_9(rect.width as u32, rect.height as u32, rect.left, rect.top);
     } else if rect.height * 8 == rect.width * 5 {
         info = info::ScanInfo::from_8_5(rect.width as u32, rect.height as u32, rect.left, rect.top);


### PR DESCRIPTION
The most common resolution of this ratio is 3440x1440, which is usually called as 21:9. However, that is not the exact ratio, and almost none of the common 21:9 resolutions are actually 21:9. This means they all requiring custom location info.

Tested with whatever was in my inventory.

另外这个Rect的定义怎么这么奇怪，一般不是左上xy右下xy么，结果这里是右上yx左下yx……