### PR TITLE
feat: support PC_cloudGenshin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,10 @@ fn main() {
 
     let hwnd = match utils::find_window("原神") {
         Err(s) => {
-            utils::error_and_quit("未找到原神窗口，请确认原神已经开启");
+            match utils::find_window("云·原神") {
+                Ok(h) => h,
+                Err(s) => utils::error_and_quit("未找到原神窗口，请确认原神已经开启"),
+            }
         },
         Ok(h) => h,
     };

--- a/src/scanner/yas_scanner.rs
+++ b/src/scanner/yas_scanner.rs
@@ -690,7 +690,12 @@ impl YasScanner {
         set_dpi_awareness();
         let hwnd = match find_window("原神") {
             Ok(v) => v,
-            Err(s) => return Err(String::from("未找到原神窗口"))
+            Err(s) => {
+                match find_window("云·原神") {
+                    Ok(v) => v,
+                    Err(s) => return Err(String::from("未找到原神窗口"))
+                }
+            }
         };
 
         show_window_and_set_foreground(hwnd);


### PR DESCRIPTION
support cloudGenshin by modify match find_window("原神") when err, match find_window("云·原神")

米哈游最近开放了PC端云原神的测试，通过修改match find_window("原神")相关代码，实现了对官方PC云原神的支持，已在我的云原神上测试成功