### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,25 +2,34 @@ name: Rust
 
 on:
   push:
-    tags:
-      - "*"
+    branches:
+      - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
-    - uses: actions/checkout@v2
-      with:
-        lfs: true
-    - name: Build
-      run: cargo build --release
-    - name: Release
-      uses: actions/upload-artifact@v2
-      with:
-        name: yas
-        path: target/release/yas.exe
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build (Debug)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: cargo build
+
+      - name: Build (Release)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: cargo build --release
+
+      - name: Upload artifact
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: yas_scanner
+          path: target/release/yas_scanner.exe


### PR DESCRIPTION
1. Update Github actions dependencies
2. Use Swatinem/rust-cache to reduce build time
3. Now we can run it manually through `workflow_dispatch`
4. Build debug target for non-release commit.
5. Update the name to adapt https://github.com/wormtql/yas/commit/3166d2eb79e810b78b1d1a66ebc403ffa6797e3c