### PR TITLE
Libwayshot support for Linux/wlroots

### DIFF
--- a/yas-derive/src/window_info/nested_attributes.rs
+++ b/yas-derive/src/window_info/nested_attributes.rs
@@ -1,15 +1,8 @@
 use syn::{token, Token};
 
+#[derive(Default)]
 pub struct WindowInfoNestedAttributes {
     pub rename: Option<syn::LitStr>,
-}
-
-impl Default for WindowInfoNestedAttributes {
-    fn default() -> Self {
-        Self {
-            rename: None
-        }
-    }
 }
 
 impl WindowInfoNestedAttributes {

--- a/yas-genshin/src/application/artifact_scanner.rs
+++ b/yas-genshin/src/application/artifact_scanner.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::{command, ArgMatches, Args};
 use log::info;
 
@@ -77,19 +77,17 @@ impl ArtifactScannerApplication {
 
         let mut scanner = GenshinArtifactScanner::from_arg_matches(
             &window_info_repository,
-            &arg_matches,
+            arg_matches,
             game_info.clone()
         )?;
 
         let result = scanner.scan()?;
         let artifacts = result
             .iter()
-            .map(|x| GenshinArtifact::try_from(x))
-            .filter(|x| x.is_ok())
-            .map(|x| x.unwrap())
+            .flat_map(GenshinArtifact::try_from)
             .collect::<Vec<_>>();
 
-        let exporter = GenshinArtifactExporter::new(&arg_matches, &artifacts)?;
+        let exporter = GenshinArtifactExporter::new(arg_matches, &artifacts)?;
         let mut export_assets = ExportAssets::new();
         exporter.emit(&mut export_assets);
 

--- a/yas-genshin/src/export/artifact/csv.rs
+++ b/yas-genshin/src/export/artifact/csv.rs
@@ -19,30 +19,30 @@ fn single_artifact_to_string(artifact: &GenshinArtifact) -> String {
         s = s + "," + &sub.name.to_string();
         s = s + "," + &format!("{}", sub.value);
     } else {
-        s = s + ",,";
+        s += ",,";
     }
     if let Some(sub) = &artifact.sub_stat_2 {
         s = s + "," + &sub.name.to_string();
         s = s + "," + &format!("{}", sub.value);
     } else {
-        s = s + ",,";
+        s += ",,";
     }
     if let Some(sub) = &artifact.sub_stat_3 {
         s = s + "," + &sub.name.to_string();
         s = s + "," + &format!("{}", sub.value);
     } else {
-        s = s + ",,";
+        s += ",,";
     }
     if let Some(sub) = &artifact.sub_stat_4 {
         s = s + "," + &sub.name.to_string();
         s = s + "," + &format!("{}", sub.value);
     } else {
-        s = s + ",,";
+        s += ",,";
     }
     if let Some(e) = &artifact.equip {
         s = s + "," + e;
     } else {
-        s = s + ","
+        s += ","
     }
 
     s

--- a/yas-genshin/src/scanner/artifact_scanner/artifact_scanner.rs
+++ b/yas-genshin/src/scanner/artifact_scanner/artifact_scanner.rs
@@ -28,7 +28,7 @@ fn color_distance(c1: &image::Rgb<u8>, c2: &image::Rgb<u8>) -> usize {
     let x = c1.0[0] as i32 - c2.0[0] as i32;
     let y = c1.0[1] as i32 - c2.0[1] as i32;
     let z = c1.0[2] as i32 - c2.0[2] as i32;
-    return (x * x + y * y + z * z) as usize;
+    (x * x + y * y + z * z) as usize
 }
 
 pub struct GenshinArtifactScanner {
@@ -127,7 +127,7 @@ impl GenshinArtifactScanner {
         let mut min_dis: usize = 0xdeadbeef;
         let mut ret: usize = 1;
         for (i, match_color) in match_colors.iter().enumerate() {
-            let dis2 = color_distance(&match_color, &color);
+            let dis2 = color_distance(match_color, &color);
             if dis2 < min_dis {
                 min_dis = dis2;
                 ret = i + 1;

--- a/yas-genshin/src/scanner/artifact_scanner/artifact_scanner_worker.rs
+++ b/yas-genshin/src/scanner/artifact_scanner/artifact_scanner_worker.rs
@@ -24,7 +24,7 @@ fn parse_level(s: &str) -> Result<i32> {
     }
 
     let level = s[pos.unwrap()..].parse::<i32>()?;
-    return anyhow::Ok(level);
+    anyhow::Ok(level)
 }
 
 fn get_image_to_text() -> Result<Box<dyn ImageToText<RgbImage> + Send>> {
@@ -73,17 +73,17 @@ impl ArtifactScannerWorker {
     fn scan_item_image(&self, item: SendItem) -> Result<GenshinArtifactScanResult> {
         let image = &item.panel_image;
 
-        let str_title = self.model_inference(self.window_info.title_rect, &image)?;
-        let str_main_stat_name = self.model_inference(self.window_info.main_stat_name_rect, &image)?;
-        let str_main_stat_value = self.model_inference(self.window_info.main_stat_value_rect, &image)?;
+        let str_title = self.model_inference(self.window_info.title_rect, image)?;
+        let str_main_stat_name = self.model_inference(self.window_info.main_stat_name_rect, image)?;
+        let str_main_stat_value = self.model_inference(self.window_info.main_stat_value_rect, image)?;
 
-        let str_sub_stat0 = self.model_inference(self.window_info.sub_stat_1, &image)?;
-        let str_sub_stat1 = self.model_inference(self.window_info.sub_stat_2, &image)?;
-        let str_sub_stat2 = self.model_inference(self.window_info.sub_stat_3, &image)?;
-        let str_sub_stat3 = self.model_inference(self.window_info.sub_stat_4, &image)?;
+        let str_sub_stat0 = self.model_inference(self.window_info.sub_stat_1, image)?;
+        let str_sub_stat1 = self.model_inference(self.window_info.sub_stat_2, image)?;
+        let str_sub_stat2 = self.model_inference(self.window_info.sub_stat_3, image)?;
+        let str_sub_stat3 = self.model_inference(self.window_info.sub_stat_4, image)?;
 
-        let str_level = self.model_inference(self.window_info.level_rect, &image)?;
-        let str_equip = self.model_inference(self.window_info.item_equip_rect, &image)?;
+        let str_level = self.model_inference(self.window_info.level_rect, image)?;
+        let str_equip = self.model_inference(self.window_info.item_equip_rect, image)?;
 
         anyhow::Ok(GenshinArtifactScanResult {
             name: str_title,
@@ -116,7 +116,7 @@ impl ArtifactScannerWorker {
             // let model = self.model.clone();
             // let panel_origin = Pos { x: self.window_info.panel_rect.left, y: self.window_info.panel_rect.top };
 
-            for (_cnt, item) in rx.into_iter().enumerate() {
+            for item in rx.into_iter() {
                 let item = match item {
                     Some(v) => v,
                     None => break,

--- a/yas-genshin/src/scanner_controller/repository_layout/controller.rs
+++ b/yas-genshin/src/scanner_controller/repository_layout/controller.rs
@@ -279,7 +279,6 @@ impl GenshinRepositoryScanController {
                 return ScrollResult::Interrupt;
             }
 
-            #[cfg(windows)]
             let _ = self.system_control.mouse_scroll(1, false);
 
             // self.mouse_scroll(1, count < 1);

--- a/yas-genshin/src/scanner_controller/repository_layout/controller.rs
+++ b/yas-genshin/src/scanner_controller/repository_layout/controller.rs
@@ -42,7 +42,7 @@ pub struct GenshinRepositoryScanController {
     capturer: Rc<dyn Capturer<RgbImage>>,
 }
 
-fn calc_pool(row: &Vec<u8>) -> f32 {
+fn calc_pool(row: &[u8]) -> f32 {
     let len = row.len() / 3;
     let mut pool: f32 = 0.0;
 
@@ -60,7 +60,7 @@ fn color_distance(c1: &image::Rgb<u8>, c2: &image::Rgb<u8>) -> usize {
     let x = c1.0[0] as i32 - c2.0[0] as i32;
     let y = c1.0[1] as i32 - c2.0[1] as i32;
     let z = c1.0[2] as i32 - c2.0[2] as i32;
-    return (x * x + y * y + z * z) as usize;
+    (x * x + y * y + z * z) as usize
 }
 
 // constructor
@@ -377,7 +377,7 @@ impl GenshinRepositoryScanController {
         self.system_control.mouse_scroll(length, try_find).unwrap();
 
         #[cfg(target_os = "linux")]
-        self.system_control.mouse_scroll(length, try_find);
+        self.system_control.mouse_scroll(length, try_find).unwrap();
 
         #[cfg(target_os = "macos")]
         {

--- a/yas/Cargo.toml
+++ b/yas/Cargo.toml
@@ -26,14 +26,14 @@ rand = "0.8"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 semver = "1.0"
 lazy_static = "1.4"
-screenshots = "0.8"
+screenshots = { version = "0.8", optional = true }
 png = "0.17"
 anyhow = "1.0"
 once_cell = "1.18"
 indicatif-log-bridge = "0.2"
 indicatif = "0.17"
 console = "0.15"
-xcap = "0.0.4"
+xcap = { version = "0.0.4", optional = true }
 paste = "1.0"
 prettytable-rs = "^0.10"
 bytesize = {version = "1.2.0", features = ["serde"]}
@@ -61,3 +61,8 @@ cocoa = "0.25"
 # default = ["tract_onnx"]
 ort = ["dep:ort", "dep:ndarray"]
 tract_onnx = ["dep:tract-onnx"]
+
+default = ["capturer_xcap", "capturer_screenshots"]
+capturer_xcap = ["dep:xcap"]
+capturer_screenshots = ["dep:screenshots"]
+

--- a/yas/Cargo.toml
+++ b/yas/Cargo.toml
@@ -40,6 +40,7 @@ bytesize = {version = "1.2.0", features = ["serde"]}
 ort = { version = "2.0.0-rc.2", optional = true }
 ndarray = { version = "0.15", optional = true }
 tract-onnx = { version = "0.21.5", optional = true }
+libwayshot = { version = "0.3.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = [
@@ -65,4 +66,5 @@ tract_onnx = ["dep:tract-onnx"]
 default = ["capturer_xcap", "capturer_screenshots"]
 capturer_xcap = ["dep:xcap"]
 capturer_screenshots = ["dep:screenshots"]
+capturer_libwayshot = ["dep:libwayshot"]
 

--- a/yas/Cargo.toml
+++ b/yas/Cargo.toml
@@ -63,7 +63,6 @@ cocoa = "0.25"
 ort = ["dep:ort", "dep:ndarray"]
 tract_onnx = ["dep:tract-onnx"]
 
-default = ["capturer_xcap", "capturer_screenshots"]
 capturer_xcap = ["dep:xcap"]
 capturer_screenshots = ["dep:screenshots"]
 capturer_libwayshot = ["dep:libwayshot"]

--- a/yas/src/capture/generic_capturer.rs
+++ b/yas/src/capture/generic_capturer.rs
@@ -1,4 +1,6 @@
-use crate::capture::{Capturer, ScreenshotsCapturer};
+use crate::capture::Capturer;
+#[cfg(feature="capturer_screenshots")]
+use crate::capture::ScreenshotsCapturer;
 #[cfg(target_os = "windows")]
 use crate::capture::WinapiCapturer;
 use anyhow::Result;
@@ -8,6 +10,7 @@ use crate::positioning::Rect;
 pub struct GenericCapturer {
     #[cfg(target_os = "windows")]
     pub windows_capturer: WinapiCapturer,
+    #[cfg(feature="capturer_screenshots")]
     pub fallback_capturer: ScreenshotsCapturer,
 }
 
@@ -16,6 +19,7 @@ impl GenericCapturer {
         Ok(Self {
             #[cfg(target_os = "windows")]
             windows_capturer: WinapiCapturer::new(),
+            #[cfg(feature="capturer_screenshots")]
             fallback_capturer: ScreenshotsCapturer::new()?,
         })
     }
@@ -31,7 +35,10 @@ impl Capturer<RgbImage> for GenericCapturer {
             }
         }
 
-        let result = self.fallback_capturer.capture_rect(rect);
-        result
+        #[cfg(feature="capturer_screenshots")]
+        {
+            let result = self.fallback_capturer.capture_rect(rect);
+            result
+        }
     }
 }

--- a/yas/src/capture/generic_capturer.rs
+++ b/yas/src/capture/generic_capturer.rs
@@ -1,4 +1,6 @@
-use crate::capture::{Capturer, ScreenshotsCapturer, WinapiCapturer};
+use crate::capture::{Capturer, ScreenshotsCapturer};
+#[cfg(target_os = "windows")]
+use crate::capture::WinapiCapturer;
 use anyhow::Result;
 use image::RgbImage;
 use crate::positioning::Rect;
@@ -30,6 +32,6 @@ impl Capturer<RgbImage> for GenericCapturer {
         }
 
         let result = self.fallback_capturer.capture_rect(rect);
-        return result;
+        result
     }
 }

--- a/yas/src/capture/libwayshot_capturer.rs
+++ b/yas/src/capture/libwayshot_capturer.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use image::{RgbaImage, RgbImage};
+use image::buffer::ConvertBuffer;
+use libwayshot::{WayshotConnection, CaptureRegion};
+use crate::capture::Capturer;
+use crate::positioning::Rect;
+
+pub struct LibwayshotCapturer {
+    conn: WayshotConnection,
+}
+
+impl LibwayshotCapturer {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            conn: WayshotConnection::new()?,
+        })
+    }
+}
+
+impl Capturer<RgbaImage> for LibwayshotCapturer {
+    fn capture_rect(&self, rect: Rect<i32>) -> Result<RgbaImage> {
+        let region = CaptureRegion {
+            x_coordinate: rect.left,
+            y_coordinate: rect.top,
+            width: rect.width,
+            height: rect.height,
+        };
+        let capture_result = self.conn.screenshot(region, false)?;
+        Ok(capture_result)
+    }
+}
+
+impl Capturer<RgbImage> for LibwayshotCapturer {
+    fn capture_rect(&self, rect: Rect<i32>) -> Result<RgbImage> {
+        let rgba_result: RgbaImage = self.capture_rect(rect)?;
+        Ok(rgba_result.convert())
+    }
+}

--- a/yas/src/capture/mod.rs
+++ b/yas/src/capture/mod.rs
@@ -1,5 +1,7 @@
 mod capturer;
+#[cfg(feature="capturer_screenshots")]
 mod screenshots_capturer;
+#[cfg(feature="capturer_xcap")]
 mod xcap_capturer;
 #[cfg(target_os = "windows")]
 mod winapi_capturer;
@@ -8,6 +10,7 @@ mod generic_capturer;
 // mod window_capture_capturer;
 
 pub use capturer::Capturer;
+#[cfg(feature="capturer_screenshots")]
 pub use screenshots_capturer::ScreenshotsCapturer;
 #[cfg(target_os = "windows")]
 pub use winapi_capturer::WinapiCapturer;

--- a/yas/src/capture/mod.rs
+++ b/yas/src/capture/mod.rs
@@ -9,5 +9,6 @@ mod generic_capturer;
 
 pub use capturer::Capturer;
 pub use screenshots_capturer::ScreenshotsCapturer;
+#[cfg(target_os = "windows")]
 pub use winapi_capturer::WinapiCapturer;
 pub use generic_capturer::GenericCapturer;

--- a/yas/src/capture/mod.rs
+++ b/yas/src/capture/mod.rs
@@ -3,6 +3,8 @@ mod capturer;
 mod screenshots_capturer;
 #[cfg(feature="capturer_xcap")]
 mod xcap_capturer;
+#[cfg(feature="capturer_libwayshot")]
+mod libwayshot_capturer;
 #[cfg(target_os = "windows")]
 mod winapi_capturer;
 mod generic_capturer;

--- a/yas/src/game_info/game_info_builder.rs
+++ b/yas/src/game_info/game_info_builder.rs
@@ -38,6 +38,7 @@ impl GameInfoBuilder {
             // crate::game_info::os::get_game_info(&["原神", "Genshin Impact", "云·原神"])
         }
         
-        // todo other platforms
+        #[cfg(target_os = "linux")]
+        crate::game_info::os::get_game_info()
     }
 }

--- a/yas/src/ocr/paddle_paddle_model/model.rs
+++ b/yas/src/ocr/paddle_paddle_model/model.rs
@@ -109,7 +109,7 @@ impl PPOCRModel {
             None
         } else {
             let count = *self.inference_count.borrow();
-            let duration = self.inference_time.borrow().clone();
+            let duration = *self.inference_time.borrow();
             Some(duration.div_f64(count as f64))
         }
     }
@@ -119,7 +119,7 @@ impl ImageToText<RgbImage> for PPOCRModel {
     fn image_to_text(&self, image: &RgbImage, _is_preprocessed: bool) -> Result<String> {
         let start_time = SystemTime::now();
 
-        let resized_image = resize_img(Shape3D::new(3, 48, 320), &image);
+        let resized_image = resize_img(Shape3D::new(3, 48, 320), image);
 
         #[cfg(feature = "ort")]
         let tensor = normalize_image_to_ndarray(&resized_image);

--- a/yas/src/ocr/yas_model/yas_ocr_model.rs
+++ b/yas/src/ocr/yas_model/yas_ocr_model.rs
@@ -114,7 +114,7 @@ impl YasOCRModel {
                 ans = ans + word;
             }
 
-            last_word = word.clone();
+            last_word.clone_from(word);
         }
 
         let time = now.elapsed()?.as_secs_f64();
@@ -126,7 +126,7 @@ impl YasOCRModel {
 
 impl ImageToText<RgbImage> for YasOCRModel {
     fn image_to_text(&self, image: &RgbImage, is_preprocessed: bool) -> Result<String> {
-        assert_eq!(is_preprocessed, false);
+        assert!(!is_preprocessed);
 
         let gray_image_float = preprocess::to_gray(image);
         let (result, non_mono) = preprocess::pre_process(gray_image_float);

--- a/yas/src/positioning/rect.rs
+++ b/yas/src/positioning/rect.rs
@@ -86,3 +86,4 @@ convert_rect_type!(u32, usize);
 convert_rect_type!(i32, usize);
 convert_rect_type!(i32, f64);
 convert_rect_type!(i32, u32);
+convert_rect_type!(usize, i32);

--- a/yas/src/system_control/linux/linux_control.rs
+++ b/yas/src/system_control/linux/linux_control.rs
@@ -1,4 +1,4 @@
-use enigo::Enigo;
+use enigo::{Enigo, MouseButton, MouseControllable};
 
 pub struct LinuxControl {
     enigo: Enigo,

--- a/yas/src/utils/misc.rs
+++ b/yas/src/utils/misc.rs
@@ -4,7 +4,7 @@ pub fn color_distance(c1: &image::Rgb<u8>, c2: &image::Rgb<u8>) -> usize {
     let x = c1.0[0] as i32 - c2.0[0] as i32;
     let y = c1.0[1] as i32 - c2.0[1] as i32;
     let z = c1.0[2] as i32 - c2.0[2] as i32;
-    return (x * x + y * y + z * z) as usize;
+    (x * x + y * y + z * z) as usize
 }
 
 pub fn press_any_key_to_continue() {

--- a/yas/src/window_info/load_window_info.rs
+++ b/yas/src/window_info/load_window_info.rs
@@ -17,7 +17,7 @@ pub struct WindowInfoTemplatePerSize {
 impl WindowInfoTemplatePerSize {
     pub fn inject_into_window_info_repo(&self, repo: &mut WindowInfoRepository) {
         for (name, value) in self.data.iter() {
-            repo.add(&name, self.current_resolution, self.ui, self.platform, *value);
+            repo.add(name, self.current_resolution, self.ui, self.platform, *value);
         }
     }
 }

--- a/yas/src/window_info/window_info_repository.rs
+++ b/yas/src/window_info/window_info_repository.rs
@@ -56,10 +56,9 @@ impl WindowInfoRepository {
     /// Get window info by name and size
     /// if name or resolution does not exist, then return None
     pub fn get_exact<T>(&self, name: &str, window_size: Size<usize>, ui: UI, platform: Platform) -> Option<T> where WindowInfoType: TryInto<T> {
-        if self.data.contains_key(name) {
-            if self.data[name].contains_key(&(window_size, ui, platform)) {
-                return self.data[name][&(window_size, ui, platform)].try_into().ok();
-            }
+        if self.data.contains_key(name) &&
+          self.data[name].contains_key(&(window_size, ui, platform)) {
+            return self.data[name][&(window_size, ui, platform)].try_into().ok();
         }
 
         None


### PR DESCRIPTION
This patch series adds support for using libwayshot to take screenshots, among other fixes.

I've tested that it works on Wayfire & 4k 2x monitor. The features need to be manually updated as desired. (I don't want to build `xcap` or `screenshots` because it has too many dependencies, especially it wants to build a copy of dbus from source.

The window info needs to be manually filled in `yas/src/game_info/os/linux.rs` and `yas-genshin/src/scanner_controller/repository_layout/controller.rs` needs to adjust for 2x HiDPI coordinates. In the long term, these adaptions could be given via command line.

Depends on #179.